### PR TITLE
Fixes missing sounds, fixes open issue "No jump sound effect in Pitfall!"

### DIFF
--- a/A2601top.vhd
+++ b/A2601top.vhd
@@ -148,6 +148,7 @@ architecture arch of A2601top is
 	constant BANKFA: bss_type := "1000";
 	constant BANKCV: bss_type := "1001";
 	constant BANK2K: bss_type := "1010";
+        constant BANKUA: bss_type := "1011";
 
 	signal bss:  bss_type := BANK00; 	--bank switching method
 	 
@@ -317,8 +318,8 @@ with cpu_a(11 downto 10) select e0_bank <=
 tf_bank <= bank(1 downto 0) when (cpu_a(11) = '0') else "11";
 
 rom_a <=
-		"00" & e0_bank & cpu_a(9 downto 0) when bss = BANKE0 else
-		"00" & tf_bank & cpu_a(10 downto 0) when bss = BANK3F else
+		"00" & e0_bank & cpu_a(9 downto 0) when bss = BANKE0 or bss = BANKUA else
+		"00" & tf_bank & cpu_a(10 downto 0) when bss = BANK3F or bss = BANKUA else
 		"0100" & std_logic_vector(2047 - DpcCounters(to_integer(unsigned(cpu_a(2 downto 0))))(10 downto 0)) when
 							bss = BANKP2 and cpu_a >= "1" & x"008" and cpu_a <= "1" & x"017" else
 		"0000" & cpu_a(10 downto 0) when bss = BANKCV else
@@ -483,6 +484,12 @@ begin
 					if (cpu_a = "0" & X"03F") then
 						bank(1 downto 0) <= cpu_do(1 downto 0);
 					end if;
+				when BANKUA =>
+                        if (cpu_a = "0" & X"220") then
+                            bank(0) <= '0';
+                        elsif (cpu_a = "0" & X"240") then
+                            bank(0) <= '1';
+                        end if;
 				when others =>
 					null;
 			end case;

--- a/A2601top.vhd
+++ b/A2601top.vhd
@@ -318,8 +318,9 @@ with cpu_a(11 downto 10) select e0_bank <=
 tf_bank <= bank(1 downto 0) when (cpu_a(11) = '0') else "11";
 
 rom_a <=
-		"00" & e0_bank & cpu_a(9 downto 0) when bss = BANKE0 or bss = BANKUA else
-		"00" & tf_bank & cpu_a(10 downto 0) when bss = BANK3F or bss = BANKUA else
+		"00" & e0_bank & cpu_a(9 downto 0) when bss = BANKE0 else
+		"00" & tf_bank & cpu_a(10 downto 0) when bss = BANK3F else
+		"00" & bank(0) & cpu_a(11 downto 0) when bss = BANKUA else
 		"0100" & std_logic_vector(2047 - DpcCounters(to_integer(unsigned(cpu_a(2 downto 0))))(10 downto 0)) when
 							bss = BANKP2 and cpu_a >= "1" & x"008" and cpu_a <= "1" & x"017" else
 		"0000" & cpu_a(10 downto 0) when bss = BANKCV else

--- a/Atari2600.sv
+++ b/Atari2600.sv
@@ -285,6 +285,7 @@ always @(posedge clk_sys) begin
 		if (ext == ".P2") force_bs <= 7; // Pitfall II
     	if (ext == ".FA") force_bs <= 8;
     	if (ext == ".CV") force_bs <= 9;
+	if (ext == ".UA") force_bs <= 10;
 	
 		sc <= (!status[10:9]) ? (ioctl_file_ext[8:0] == "S") : status[10];
 	end

--- a/TIA.vhd
+++ b/TIA.vhd
@@ -732,8 +732,8 @@ begin
     hh0 <= '1' when (h_cntr_out = "00") else '0';
     hh1_edge <= '1' when (h_cntr_out = "10") else '0';
 
-    aud0: work.audio port map(clk, au_cnt, a0_freq, a0_ctrl, au0);
-    aud1: work.audio port map(clk, au_cnt, a1_freq, a1_ctrl, au1);
+    aud0: work.audio_argh2600 port map(clk, au_cnt, a0_freq, a0_ctrl, au0);
+    aud1: work.audio_argh2600 port map(clk, au_cnt, a1_freq, a1_ctrl, au1);
 
     av0 <= a0_vol;
     av1 <= a1_vol;

--- a/audio_argh2600.vhd
+++ b/audio_argh2600.vhd
@@ -1,0 +1,225 @@
+-- Copyright (c) 2014, Juha Turunen
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met: 
+--
+-- 1. Redistributions of source code must retain the above copyright notice, this
+--    list of conditions and the following disclaimer. 
+-- 2. Redistributions in binary form must reproduce the above copyright notice,
+--    this list of conditions and the following disclaimer in the documentation
+--    and/or other materials provided with the distribution. 
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-- DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-- ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+-- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+use IEEE.STD_LOGIC_ARITH.ALL;
+use IEEE.STD_LOGIC_UNSIGNED.ALL;
+
+entity audio_argh2600 is 
+port 
+(
+	clk : in std_logic;
+	clk_audio : in std_logic;
+	freq : in std_logic_vector(4 downto 0); 	-- AUDF
+	ctrl : in std_logic_vector(3 downto 0); 	-- AUDC
+	output : out std_logic
+);
+end audio_argh2600;
+
+architecture Behavioral of audio_argh2600 is
+
+signal w: std_logic;
+signal f_counter : std_logic_vector(4 downto 0) := (others=>'0'); 
+signal toggled, toggled_next : std_logic;
+
+signal cnt3, cnt3_next : std_logic_vector(1 downto 0);
+signal cnt3_ena : std_logic;
+
+signal lfsr4, lfsr4_next : std_logic_vector(3 downto 0);
+signal lfsr5, lfsr5_next : std_logic_vector(4 downto 0);
+signal lfsr9, lfsr9_next : std_logic_vector(8 downto 0);
+signal lfsr4_clk_audio : std_logic;
+signal lfsr4_out, lfsr5_out, lfsr9_out : std_logic;
+signal lfsr5_edge : std_logic;
+
+signal div31_edge, div6_edge : std_logic;
+
+begin
+	process(clk, clk_audio)
+
+	-- prescalers
+	begin
+		if (clk'event and clk = '1' and clk_audio = '1') then
+
+				if (f_counter = freq) then
+
+						f_counter <= "00000";
+
+						if (lfsr4_clk_audio = '1') then
+							lfsr4 <= lfsr4_next;
+						end if;
+
+						lfsr5 <= lfsr5_next;
+						lfsr9 <= lfsr9_next;
+						toggled <= toggled_next;
+
+						if (cnt3_ena = '1') then
+							cnt3 <= cnt3_next;
+						end if;
+
+				else
+
+						f_counter <= f_counter + 1;
+
+				end if;
+
+		end if;
+	end process;
+
+	lfsr5_edge <= '1' when 
+							--(lfsr5(1 downto 0) = "10" or lfsr5(1 downto 0) = "01") -- original
+							--lfsr5(4 downto 2) = "100"
+							lfsr5(4 downto 1) = "0110"
+							else '0';
+
+	div31_edge <= '1' when lfsr5 = "11111" or lfsr5 = "10000" else '0';
+	div6_edge  <= '1' when cnt3 = "10" else '0';
+
+
+	-- The Audio Control register generates and manipulates a pulse wave to create complex pulses or noise. The following table (with designed duplicates) explains how its tones are generated:
+	-- 
+	-- HEX	D7	D6	D5	D4	D3	D2	D1	D0	Type of noise or division
+	-- 0					0	0	0	0	Set to 1 (volume only)
+	-- 1					0	0	0	1	4 bit poly
+	-- 2					0	0	1	0	÷ 15 → 4 bit poly
+	-- 3					0	0	1	1	5 bit poly → 4 bit poly
+	-- 4					0	1	0	0	÷ 2
+	-- 5					0	1	0	1	÷ 2
+	-- 6					0	1	1	0	÷ 31
+	-- 7					0	1	1	1	5 bit poly → ÷ 2
+	-- 8					1	0	0	0	9-bit poly (white noise)
+	-- 9					1	0	0	1	5-bit poly
+	-- A					1	0	1	0	÷ 31
+	-- B					1	0	1	1	Set last 4 bits to 1
+	-- C					1	1	0	0	÷ 6
+	-- D					1	1	0	1	÷ 6
+	-- E					1	1	1	0	÷ 93
+	-- F					1	1	1	1	5-bit poly ÷ 6
+
+
+	process (ctrl, toggled, lfsr4_out, lfsr5_out, lfsr9_out, lfsr5_edge, div31_edge, div6_edge)
+	begin
+
+		lfsr4_clk_audio <= '1';
+		toggled_next <= toggled;
+		cnt3_ena <= '1';
+
+		case ctrl is 
+
+			when "0000" => 		-- 0
+				w <= '1';
+
+			when "0001" => 		-- 1            	-- 1, 2, 3, queda, corda, morte no pitfall
+				w <= lfsr4_out;
+
+			when "0010" => 		-- 2
+				w <= lfsr4_out;
+				lfsr4_clk_audio <= div31_edge;
+
+			when "0011" => 		-- 3
+				w <= lfsr4_out;
+				lfsr4_clk_audio <= lfsr5_out;
+
+			when "0100" => 		-- 4     			-- 4, 5, 6, nada no sequest
+				w <= toggled;
+				toggled_next <= not toggled;
+
+			when "0101" => 		-- 5
+				w <= toggled;
+				toggled_next <= not toggled;
+
+			when "0110" => 		-- 6
+				w <= toggled;
+				if (div31_edge = '1') then
+					toggled_next <= not toggled;
+				end if;
+
+			when "0111" => 		-- 7              -- 7, 8, 9, tronco no pitfall, ar e explosao no sequest
+				w <= lfsr5_out;
+
+			when "1000" =>			-- 8
+				w <= lfsr9_out;
+
+			when "1001" =>			-- 9
+				w <= lfsr5_out;
+
+			when "1010" =>			-- A     			-- a, b, c, morte do peixe no seaquest
+				w <= toggled;
+				if (div31_edge = '1') then
+					toggled_next <= not toggled;
+				end if;
+
+			when "1011" =>			-- B
+				w <= '1';
+
+			when "1100" =>			-- C
+				w <= toggled;
+				if (div6_edge = '1') then
+					toggled_next <= not toggled;
+				end if;
+
+			when "1101" =>			-- D
+				w <= toggled;
+				if (div6_edge = '1') then
+					toggled_next <= not toggled;
+				end if;
+
+			when "1110" =>			-- E
+				w <= toggled;
+				cnt3_ena <= div31_edge;
+				if (div6_edge = '1') then
+					toggled_next <= not toggled;
+				end if;
+
+			when "1111" =>			-- F         		-- F, tiro e morte no sequest
+				w <= toggled;
+				if (lfsr5_edge = '1') then
+					toggled_next <= not toggled;
+				end if;
+
+			when others =>
+				null;
+
+		end case;
+	end process;
+
+	cnt3_next <= "00" when cnt3 ="10" else cnt3 + 1;
+
+	lfsr4_next <= "1111" when lfsr4 = "0000" else 
+					  (lfsr4(0) xor lfsr4(1)) & lfsr4(3 downto 1);
+
+	lfsr5_next <= "11111" when lfsr5 = "00000" else 
+					  (lfsr5(0) xor lfsr5(2)) & lfsr5(4 downto 1); 
+
+	lfsr9_next <= "111111111" when lfsr9 = "000000000" else
+					  (lfsr9(0) xor lfsr9(4)) & lfsr9(8 downto 1);
+
+	lfsr4_out <= lfsr4(0);
+	lfsr5_out <= lfsr5(0);
+	lfsr9_out <= lfsr9(0);
+
+	output <= w;
+
+end Behavioral;

--- a/files.qip
+++ b/files.qip
@@ -2,6 +2,7 @@ set_global_assignment -name VHDL_FILE cpu65xx.vhd
 set_global_assignment -name VHDL_FILE Common.vhd
 set_global_assignment -name VHDL_FILE VGAColorTable.vhd
 set_global_assignment -name VHDL_FILE TIA.vhd
+set_global_assignment -name VHDL_FILE audio_argh2600.vhd
 set_global_assignment -name VHDL_FILE A6532.vhd
 set_global_assignment -name VHDL_FILE A6507.vhd
 set_global_assignment -name VHDL_FILE A2601Core.vhd


### PR DESCRIPTION
Tested my favorite 40 games. All but one sound good / better.

- fixes missing sound in Pitfall!
- fixes missing sound in Mouse Trap (eating cat's sound).

- but sound in Space Invaders Pal when "hit by alien and you are destroyed" is now wrong. (the 4 high tones when destroyed shall not be there). Original TIA Audio module (before) is correct.


