### PR TITLE
.e7 M-Net Mapper

### DIFF
--- a/A2601top.vhd
+++ b/A2601top.vhd
@@ -259,13 +259,15 @@ audio <= std_logic_vector(auv0 + auv1);
 
 ram: work.ramx8 generic map(11) port map(clk, sc_r, cpu_do, sc_d_out, sc_a);
 
-sc_r <= '0' when (cpu_a(12 downto 10) = "101" and bss = BANKCV) or
-                 (cpu_a(12 downto  8) = "10000" and bss = BANKFA) or 
-	         '1' when cpu_a(12 downto 11) = "10" and bss = BANKE7 and (cpu_a(10) = '1' or e7_bank0 /= "111") else -- 1400 - 17ff
-                 '0' when cpu_a(12 downto 10) = "100" and bss = BANKE7 and e7_bank0 = "111" else -- 1000-13ff
-                 '1' when cpu_a(12 downto  8) = "11001" and bss = BANKE7 else
-                 '0' when cpu_a(12 downto  8) = "11000" and bss = BANKE7 else
-                 (cpu_a(12 downto  7) = "100000" and sc = '1') or reset = '1' else '1';
+sc_r <= '1' when cpu_a(12 downto 10) = "100" and bss = BANKCV else
+                 0' when cpu_a(12 downto 10) = "101" and bss = BANKCV else
+            	'1' when cpu_a(12 downto  8) = "10001" and bss = BANKFA else
+            	'0' when cpu_a(12 downto  8) = "10000" and bss = BANKFA else
+	        '1' when cpu_a(12 downto 11) = "10" and bss = BANKE7 and (cpu_a(10) = '1' or e7_bank0 /= "111") else -- 1400 - 17ff
+                '0' when cpu_a(12 downto 10) = "100" and bss = BANKE7 and e7_bank0 = "111" else -- 1000-13ff
+                '1' when cpu_a(12 downto  8) = "11001" and bss = BANKE7 else
+                '0' when cpu_a(12 downto  8) = "11000" and bss = BANKE7 else
+                (cpu_a(12 downto  7) = "100000" and sc = '1') or reset = '1' else '1';
 	
 
  sc_a <=

--- a/A2601top.vhd
+++ b/A2601top.vhd
@@ -267,7 +267,7 @@ sc_r <= '1' when cpu_a(12 downto 10) = "100" and bss = BANKCV else
                 '0' when cpu_a(12 downto 10) = "100" and bss = BANKE7 and e7_bank0 = "111" else -- 1000-13ff
                 '1' when cpu_a(12 downto  8) = "11001" and bss = BANKE7 else
                 '0' when cpu_a(12 downto  8) = "11000" and bss = BANKE7 else
-                '0' when cpu_a(12 downto  7) = "100000" and sc = '1') else '1'; -- or reset = '1'
+                (cpu_a(12 downto  7) = "100000" and sc = '1') or reset = '1' else '1';
 	
 
  sc_a <=

--- a/A2601top.vhd
+++ b/A2601top.vhd
@@ -152,7 +152,7 @@ architecture arch of A2601top is
 	constant BANKCV: bss_type := "1001";
 	constant BANK2K: bss_type := "1010";
 	constant BANKUA: bss_type := "1011";
-	constant BANKE7: bss_type := "1010";
+	constant BANKE7: bss_type := "1100";
 
 	signal bss:  bss_type := BANK00; 	--bank switching method
 	 

--- a/A2601top.vhd
+++ b/A2601top.vhd
@@ -267,16 +267,17 @@ sc_r <= '1' when cpu_a(12 downto 10) = "100" and bss = BANKCV else
                 '0' when cpu_a(12 downto 10) = "100" and bss = BANKE7 and e7_bank0 = "111" else -- 1000-13ff
                 '1' when cpu_a(12 downto  8) = "11001" and bss = BANKE7 else
                 '0' when cpu_a(12 downto  8) = "11000" and bss = BANKE7 else
-                (cpu_a(12 downto  7) = "100000" and sc = '1') or reset = '1' else '1';
-	
-
+                '0' when cpu_a(12 downto  7) = "100000" and sc = '1' else '1';
+				
  sc_a <=
          "0" & cpu_a(9 downto 0) when bss = BANKCV else
        "000" & cpu_a(7 downto 0) when bss = BANKFA else
-	     "0" & cpu_a(9 downto 0) when bss = BANKE7 and cpu_a(12 downto 11) = "10" else
+	 "0" & cpu_a(9 downto 0) when bss = BANKE7 and cpu_a(12 downto 11) = "10" else
          "1" & e7_rambank & cpu_a(7 downto 0) when bss = BANKE7 and cpu_a(12 downto 9) = "1100" else
       "0000" & cpu_a(6 downto 0);
 
+		 
+		 
 -- ROM and SC output
 process(cpu_a, rom_do, sc_d_out, sc, bss, DpcFlags, DpcRandom, DpcMusicModes, DpcMusicFlags, soundAmplitudes)
 	variable ampI_v :std_logic_vector(2 downto 0);
@@ -312,7 +313,7 @@ begin
 		cpu_di <= x"FF";
 
 	elsif bss = BANKE7 and cpu_a(12 downto 11) = "101" and e7_bank0 = "111" then
-			cpu_d <= sc_d_out;
+			cpu_di <= sc_d_out;
 		elsif bss = BANKE7 and cpu_a(12 downto 11) = "100" and e7_bank0 = "111" then
 			cpu_di <= x"FF";
 		elsif bss = BANKE7 and cpu_a(12 downto 8) = "11001" then

--- a/A2601top.vhd
+++ b/A2601top.vhd
@@ -267,7 +267,7 @@ sc_r <= '1' when cpu_a(12 downto 10) = "100" and bss = BANKCV else
                 '0' when cpu_a(12 downto 10) = "100" and bss = BANKE7 and e7_bank0 = "111" else -- 1000-13ff
                 '1' when cpu_a(12 downto  8) = "11001" and bss = BANKE7 else
                 '0' when cpu_a(12 downto  8) = "11000" and bss = BANKE7 else
-                (cpu_a(12 downto  7) = "100000" and sc = '1') or reset = '1' else '1';
+                '0' when cpu_a(12 downto  7) = "100000" and sc = '1') or reset = '1' else '1';
 	
 
  sc_a <=

--- a/A2601top.vhd
+++ b/A2601top.vhd
@@ -260,7 +260,7 @@ audio <= std_logic_vector(auv0 + auv1);
 ram: work.ramx8 generic map(11) port map(clk, sc_r, cpu_do, sc_d_out, sc_a);
 
 sc_r <= '1' when cpu_a(12 downto 10) = "100" and bss = BANKCV else
-                 0' when cpu_a(12 downto 10) = "101" and bss = BANKCV else
+                '0' when cpu_a(12 downto 10) = "101" and bss = BANKCV else
             	'1' when cpu_a(12 downto  8) = "10001" and bss = BANKFA else
             	'0' when cpu_a(12 downto  8) = "10000" and bss = BANKFA else
 	        '1' when cpu_a(12 downto 11) = "10" and bss = BANKE7 and (cpu_a(10) = '1' or e7_bank0 /= "111") else -- 1400 - 17ff

--- a/A2601top.vhd
+++ b/A2601top.vhd
@@ -267,7 +267,7 @@ sc_r <= '1' when cpu_a(12 downto 10) = "100" and bss = BANKCV else
                 '0' when cpu_a(12 downto 10) = "100" and bss = BANKE7 and e7_bank0 = "111" else -- 1000-13ff
                 '1' when cpu_a(12 downto  8) = "11001" and bss = BANKE7 else
                 '0' when cpu_a(12 downto  8) = "11000" and bss = BANKE7 else
-                '0' when cpu_a(12 downto  7) = "100000" and sc = '1') or reset = '1' else '1';
+                '0' when cpu_a(12 downto  7) = "100000" and sc = '1') else '1'; -- or reset = '1'
 	
 
  sc_a <=

--- a/A2601top.vhd
+++ b/A2601top.vhd
@@ -267,7 +267,7 @@ sc_r <= '1' when cpu_a(12 downto 10) = "100" and bss = BANKCV else
                 '0' when cpu_a(12 downto 10) = "100" and bss = BANKE7 and e7_bank0 = "111" else -- 1000-13ff
                 '1' when cpu_a(12 downto  8) = "11001" and bss = BANKE7 else
                 '0' when cpu_a(12 downto  8) = "11000" and bss = BANKE7 else
-                '0' when cpu_a(12 downto  7) = "100000" and sc = '1' else '1';
+                '0' when (cpu_a(12 downto  7) = "100000" and sc = '1') or reset = '1' else '1';
 				
  sc_a <=
          "0" & cpu_a(9 downto 0) when bss = BANKCV else

--- a/Atari2600.sv
+++ b/Atari2600.sv
@@ -286,6 +286,8 @@ always @(posedge clk_sys) begin
     	if (ext == ".FA") force_bs <= 8;
     	if (ext == ".CV") force_bs <= 9;
     	if (ext == ".UA") force_bs <= 11;
+	if (ext == ".E7") force_bs <= 12;
+		
 	
 		sc <= (!status[10:9]) ? (ioctl_file_ext[8:0] == "S") : status[10];
 	end

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Supported options for paddle:
 * Auto detected: F8, FA, F6, F4, FA
 * Manual set through file extension(ex: my_game.E0) : E0, FE, 3F, P2(PitFall II), CV
 * SuperChip (128b RAM). 's' can be added to extension to automatically enable SuperChip (i.e. my_game.00s).
-* Any mapper can be forced through file extension. Supported extensions: F8, F6, FE, E0, 3F, F4, P2, FA, CV, UA
+* Any mapper can be forced through file extension. Supported extensions: F8, F6, FE, E0, 3F, F4, P2, FA, CV, UA, E7
 
 
 ## Download precompiled binaries

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Supported options for paddle:
 * Auto detected: F8, FA, F6, F4, FA
 * Manual set through file extension(ex: my_game.E0) : E0, FE, 3F, P2(PitFall II), CV
 * SuperChip (128b RAM). 's' can be added to extension to automatically enable SuperChip (i.e. my_game.00s).
-* Any mapper can be forced through file extension. Supported extensions: F8, F6, FE, E0, 3F, F4, P2, FA, CV
+* Any mapper can be forced through file extension. Supported extensions: F8, F6, FE, E0, 3F, F4, P2, FA, CV, UA
 
 
 ## Download precompiled binaries


### PR DESCRIPTION
Hi Alexey,

the bad: I messed 2600.sv again. Tried Notepad++ on Windows but it still messed up.
- add line: 279       if (ext == ".E7") force_bs <= 12;

the good: I fully ported the complicated .e7 Mapper and it's working! I learned by your changes that the constant bank types in A2601top.vhd are binary which are converted to decimal in 2600.sv. Now I got it!

Also I wrote down all the variables of MIST Version compared to MISTer Version so it was easier to port them.

Now you can play:
- Burger Time NTSC
- Bump'n'Jump NTSC (please use 16k Version, 8k ROM File will not work).*
- Master Of The Universe. (Difficulty P1: A = day, B=night, Difficulty P2 = must to be A. If P2= B you cannot move the spaceship).

* According to: https://datomatic.no-intro.org/?page=show_record&s=88&n=0057
the Bump'n'Jump 16k ROM is a bad dump
but according: to https://atariage.com/forums/topic/232309-bump-n-jump-closer-look/
it dumps to 16k but the first 8k are empty. So I think 16k is the right one for real HW?

regards,
PhantombrainM